### PR TITLE
[WIP] Add first set of routes and handlers

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -135,9 +135,31 @@ func registerHomeHandler() {
 	App.Get("/:slug/", statsChain.Final(handler.ContentHandler))
 }
 
+func registerAPIHandler() {
+	// register the API handler
+	App.Get("/api", handler.APIDocumentationHandler)
+
+	// Posts
+	App.Get("/api/posts", handler.APIPostsHandler)
+	App.Get("/api/posts/:id", handler.APIPostHandler)
+	App.Get("/api/posts/slug/:slug", handler.APIPostSlugHandler)
+
+	// Tags
+	App.Get("/api/tags", handler.APITagsHandler)
+	App.Get("/api/tags/:id", handler.APITagHandler)
+	App.Get("/api/tags/slug/:slug", handler.APITagSlugHandler)
+
+	// Users
+	App.Get("/api/users", handler.APIUsersHandler)
+	App.Get("/api/users/:id", handler.APIUserHandler)
+	App.Get("/api/users/slug/:slug", handler.APIUserSlugHandler)
+	App.Get("/api/users/email/:email", handler.APIUserEmailHandler)
+}
+
 func Run(portNumber string) {
 	registerAdminURLHandlers()
 	registerHomeHandler()
+	registerAPIHandler()
 	fmt.Printf("Application Started on port %s\n", portNumber)
 	App.Run(":" + portNumber)
 }

--- a/app/handler/api.go
+++ b/app/handler/api.go
@@ -1,0 +1,152 @@
+package handler
+
+import (
+	"github.com/dinever/dingo/app/model"
+	"github.com/dinever/golf"
+	"strconv"
+)
+
+// APIDocumentationHandler shows which routes match with what functionality,
+// similar to https://api.github.com
+func APIDocumentationHandler(ctx *golf.Context) {
+	// Go doesn't display maps in the order they appear here, so if the order
+	// of these routes is important, it might be better to use a struct
+	routes := map[string]interface{}{
+		"api_documentation_url": "/api/",
+		"posts_url":             "/api/posts/",
+		"post_url":              "/api/posts/:id",
+		"post_slug_url":         "/api/posts/slug/:slug",
+		"tags_url":              "/api/tags/",
+		"tag_url":               "/api/tags/:id",
+		"tag_slug_url":          "/api/tags/slug/:slug",
+		"users_url":             "/api/users/",
+		"user_url":              "/api/users/:id",
+		"user_slug_url":         "/api/users/slug/:slug",
+		"user_email_url":        "/api/users/email/:email",
+	}
+	ctx.JSONIndent(routes, "", "  ")
+}
+
+// APIPostsHandler gets every page, ordered by publication date.
+func APIPostsHandler(ctx *golf.Context) {
+	posts, err := model.GetAllPostList(false, true, "published_at DESC")
+	if err != nil {
+		handleErr(ctx, 404, err)
+		return
+	}
+	ctx.JSONIndent(posts, "", "  ")
+}
+
+// APIPostHandler retrieves the post with the given ID.
+func APIPostHandler(ctx *golf.Context) {
+	id, err := strconv.Atoi(ctx.Param("id"))
+	if err != nil {
+		handleErr(ctx, 500, err)
+		return
+	}
+	post, err := model.GetPostById(int64(id))
+	if err != nil {
+		handleErr(ctx, 404, err)
+		return
+	}
+	ctx.JSONIndent(post, "", "  ")
+}
+
+// APIPostSlugHandler retrieves the post with the given slug.
+func APIPostSlugHandler(ctx *golf.Context) {
+	slug := ctx.Param("slug")
+	posts, err := model.GetPostBySlug(slug)
+	if err != nil {
+		handleErr(ctx, 404, err)
+		return
+	}
+	ctx.JSONIndent(posts, "", "  ")
+}
+
+// APITagsHandler retrieves all the tags.
+func APITagsHandler(ctx *golf.Context) {
+	tags, err := model.GetAllTags()
+	if err != nil {
+		handleErr(ctx, 404, err)
+		return
+	}
+	ctx.JSONIndent(tags, "", "  ")
+}
+
+// APITagHandler retrieves the tag with the given id.
+func APITagHandler(ctx *golf.Context) {
+	id, err := strconv.Atoi(ctx.Param("id"))
+	if err != nil {
+		handleErr(ctx, 500, err)
+		return
+	}
+	tag, err := model.GetTag(int64(id))
+	if err != nil {
+		handleErr(ctx, 404, err)
+		return
+	}
+	ctx.JSONIndent(tag, "", "  ")
+}
+
+// APITagSlugHandler retrieves the tag(s) with the given slug.
+func APITagSlugHandler(ctx *golf.Context) {
+	slug := ctx.Param("slug")
+	tags, err := model.GetTagBySlug(slug)
+	if err != nil {
+		handleErr(ctx, 500, err)
+		return
+	}
+	ctx.JSONIndent(tags, "", "  ")
+}
+
+// APIUsersHandler retrieves all users.
+func APIUsersHandler(ctx *golf.Context) {
+	ctx.JSONIndent(map[string]interface{}{
+		"message": "Not implemented",
+	}, "", "  ")
+}
+
+// APIUserHandler retrieves the user with the given id.
+func APIUserHandler(ctx *golf.Context) {
+	id, err := strconv.Atoi(ctx.Param("id"))
+	if err != nil {
+		handleErr(ctx, 500, err)
+		return
+	}
+	user, err := model.GetUserById(int64(id))
+	if err != nil {
+		handleErr(ctx, 404, err)
+		return
+	}
+	ctx.JSONIndent(user, "", "  ")
+}
+
+// APIUserSlugHandler retrives the user with the given slug.
+func APIUserSlugHandler(ctx *golf.Context) {
+	slug := ctx.Param("slug")
+	user, err := model.GetUserBySlug(slug)
+	if err != nil {
+		handleErr(ctx, 404, err)
+		return
+	}
+	ctx.JSONIndent(user, "", "  ")
+}
+
+// APIUserEmailHandler retrieves the user with the given email.
+func APIUserEmailHandler(ctx *golf.Context) {
+	email := ctx.Param("email")
+	user, err := model.GetUserByEmail(email)
+	if err != nil {
+		handleErr(ctx, 404, err)
+		return
+	}
+	ctx.JSONIndent(user, "", "  ")
+}
+
+// handleErr sends the staus code and error message formatted as JSON.
+func handleErr(ctx *golf.Context, statusCode int, err error) {
+	ctx.JSONIndent(map[string]interface{}{
+		"statusCode": statusCode,
+		"error":      err.Error(),
+	}, "", "  ")
+}

--- a/app/handler/api_test.go
+++ b/app/handler/api_test.go
@@ -1,0 +1,49 @@
+package handler
+
+import (
+	// . "github.com/smartystreets/goconvey/convey"
+	// "net/http"
+	// "net/http/httptest"
+	"testing"
+)
+
+func TestAPIPostsHandler(t *testing.T) {
+	// FailNow due to lack of test coverage -- don't want to pass CI
+	t.FailNow()
+}
+
+func TestAPIPostHandler(t *testing.T) {
+
+}
+
+func TestAPIPostSlugHandler(t *testing.T) {
+
+}
+
+func TestAPITagsHandler(t *testing.T) {
+
+}
+
+func TestAPITagHandler(t *testing.T) {
+
+}
+
+func TestAPITagSlugHandler(t *testing.T) {
+
+}
+
+func TestAPIUsersHandler(t *testing.T) {
+
+}
+
+func TestAPIUserHandler(t *testing.T) {
+
+}
+
+func TestAPIUserSlugHandler(t *testing.T) {
+
+}
+
+func TestAPIUserEmailHandler(t *testing.T) {
+
+}


### PR DESCRIPTION
This PR is a work-in-progress, and once completed and merged would resolve #6. Mostly looking for feedback at this point (am I on the right track, does the code style look ok, etc), but also wanted to ask a few questions.

1. For now, I've followed Ghost's API routes exactly, but I know the model package allows for some more functionality. Were you hoping to have more routes in order to more closely match all the functionality in the model package?
2. Are you looking to have a read-only API (ie, only support `GET` methods), or are you hoping for the API to match the functionality the web app provides? I'm assuming we'll want to support everything, but will require a way to restrict API use to authenticated users, which brings me to my third question.
3. For authenticated routes, what's the best way to handle it? I've been thinking something like,

```http
POST /api/auth HTTP/1.1
Content-Type: application/json

{
  "username": "some_username",
  "password": "some_password"
}
```

and then sending the token in the response (either as a cookie for web based API clients, or in the body for mobile), and then protecting specific routes with the existing `AuthMiddleware` (although it would need to be modified for mobile clients who don't support cookies).